### PR TITLE
Edited a small bug

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,7 +19,7 @@ module.exports = {
       resolve: 'gatsby-source-prismic',
       options: {
         repositoryName: 'gatsby-starter-portfolio-bella',
-        accessToken: `${process.env.API_KEY}`,
+        API_KEY: `${process.env.API_KEY}`,
         linkResolver: ({ node, key, value }) => doc => `/${doc.uid}`,
         htmlSerializer: ({ node, key, value }) => (type, element, content, children) => {
           // Your HTML serializer


### PR DESCRIPTION
`accessToken` in the file `gatsby-config.js` gave a GraphQl error upon build. I figured this could have been because there was no name calling it. So I replaced this with `API_KEY`